### PR TITLE
Update types in @reach/router

### DIFF
--- a/definitions/npm/@reach/router_v1.1.x/flow_v0.63.x-/router_v1.1.x.js
+++ b/definitions/npm/@reach/router_v1.1.x/flow_v0.63.x-/router_v1.1.x.js
@@ -1,7 +1,7 @@
 // @flow
 
 declare module '@reach/router' {
-  declare type NavigateFn = (to: string, options?: NavigateOptions<{}>) => void;
+  declare type NavigateFn = (to: string, options?: NavigateOptions<{}>) => Promise<void>;
   declare export var navigate: NavigateFn;
 
   declare export type HistoryListener = () => void;
@@ -79,6 +79,7 @@ declare module '@reach/router' {
     from?: string,
     to: string,
     noThrow?: boolean,
+    default?: boolean
   |}> {}
 
   declare export class Match<Params> extends React$Component<{|

--- a/definitions/npm/@reach/router_v1.1.x/flow_v0.63.x-/test_router_v1.1.x.js
+++ b/definitions/npm/@reach/router_v1.1.x/flow_v0.63.x-/test_router_v1.1.x.js
@@ -99,7 +99,7 @@ describe('@reach/router', () => {
     it('works', () => {
       <Redirect from="aboutus" to="about-us" />;
       <Redirect from="users/:userId" to="profile/:userId" />;
-      <Redirect to="/" noThrow />;
+      <Redirect to="/" noThrow default />;
     });
 
     it('raises error', () => {
@@ -109,6 +109,8 @@ describe('@reach/router', () => {
       <Redirect to={{}} />;
       // $ExpectError - noThrow must be a boolean
       <Redirect to="/" noThrow="" />;
+      // $ExpectError - default must be a boolean
+      <Redirect to="/" default="" />;
     });
   });
 


### PR DESCRIPTION
Based on [this file](https://github.com/reach/router/blob/b60e6dd781d5d3a4bdaaf4de665649c0f6a7e78d/src/lib/history.js#L60-L62) `navigate`, should return a `Promise<void>` instead of `void`.

`Redirect` should accept a `default` prop when used as a child of `Router`, but it looks like there are no restrictions on the `children` of `Router`, so I just added it to the base definition of `Redirect`.